### PR TITLE
feat: APP_BASE_PATH config to set app as subpath

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ TURNSTILE_BOT_ALLOWLIST=discordbot,twitterbot,slackbot,facebookexternalhit,linke
 # =========================
 # Site / UI
 # =========================
+# When the map is served under a subpath (e.g. https://host/livemap/), set this
+# to that path prefix (leading slash, no trailing slash). Leave empty for /
+# root.
+# APP_BASE_PATH=/livemap
 SITE_TITLE=Anonymous Mesh Live Map
 SITE_DESCRIPTION=Live view of mesh nodes, message routes, and advert paths.
 SITE_OG_IMAGE=

--- a/backend/app.py
+++ b/backend/app.py
@@ -22,7 +22,13 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
-from urllib.parse import urlencode, parse_qsl, urlsplit, urlunsplit
+from urllib.parse import (
+  urlencode,
+  parse_qsl,
+  urlsplit,
+  urlunsplit,
+  urlparse,
+)
 from io import BytesIO
 from PIL import Image, ImageDraw
 import math
@@ -241,6 +247,24 @@ def _public_if_root_relative(url: str) -> str:
 
 def _session_cookie_path() -> str:
   return APP_BASE_PATH if APP_BASE_PATH else "/"
+
+
+def _http_site_origin(request: Request) -> str:
+  """Scheme + host for absolute public URLs (OG previews, embeds)."""
+  su = (SITE_URL or "").strip()
+  if su.startswith("http"):
+    parsed = urlparse(su)
+    if parsed.netloc:
+      return f"{parsed.scheme}://{parsed.netloc}"
+  scheme = request.url.scheme
+  host = request.headers.get("host", request.url.hostname or "localhost")
+  return f"{scheme}://{host}"
+
+
+def _public_preview_png_url(request: Request, query: str) -> str:
+  """Absolute URL for preview.png including APP_BASE_PATH."""
+  path = public_app_path("/preview.png")
+  return f"{_http_site_origin(request)}{path}?{query}"
 
 
 def _client_los_proxy_url() -> str:
@@ -2704,9 +2728,8 @@ def root(request: Request):
       zoom = int(zoom_param) if zoom_param and zoom_param.isdigit() else 13
       zoom = max(1, min(18, zoom))  # Clamp zoom between 1-18
 
-      # Generate preview image URL pointing to our own server
-      # Use absolute URL for better compatibility with Discord and other platforms
-      base_url = str(request.url).split("?")[0].rstrip("/")
+      # Generate preview image URL pointing to our own server (must include
+      # APP_BASE_PATH when the map is not served at the site root).
       preview_params = urlencode(
         {
           "lat": lat,
@@ -2716,18 +2739,7 @@ def root(request: Request):
           "theme": "dark",
         }
       )
-      preview_url = f"{base_url}/preview.png?{preview_params}"
-
-      # Ensure absolute URL (use SITE_URL if available, otherwise construct from request)
-      if SITE_URL and SITE_URL.startswith("http"):
-        site_base = SITE_URL.rstrip("/")
-        preview_url = f"{site_base}/preview.png?{preview_params}"
-      elif not preview_url.startswith("http"):
-        # Fallback: construct from request
-        scheme = request.url.scheme
-        host = request.headers.get("host", request.url.hostname or "localhost")
-        preview_path = public_app_path("/preview.png")
-        preview_url = f"{scheme}://{host}{preview_path}?{preview_params}"
+      preview_url = _public_preview_png_url(request, preview_params)
 
       safe_image = html.escape(preview_url, quote=True)
       # Add image dimensions for better Discord/social media compatibility
@@ -2746,9 +2758,11 @@ def root(request: Request):
         safe_static_image = html.escape(str(SITE_OG_IMAGE), quote=True)
         og_image_tag += f'\n  <meta property="og:image:secure_url" content="{safe_static_image}" />'
 
-      # Update og:url to include query parameters
-      base_url = str(request.url).split("?")[0]
-      og_url = f"{base_url}?lat={lat}&lon={lon}"
+      # Update og:url to include query parameters (same path prefix as map).
+      base_page = (
+        _http_site_origin(request) + public_app_path("/").rstrip("/")
+      )
+      og_url = f"{base_page}?lat={lat}&lon={lon}"
       if zoom_param:
         og_url += f"&zoom={zoom}"
     except (ValueError, TypeError):

--- a/backend/app.py
+++ b/backend/app.py
@@ -190,6 +190,8 @@ from config import (
   APP_VERSION,
   APP_DIR,
   NODE_SCRIPT_PATH,
+  APP_BASE_PATH,
+  public_app_path,
 )
 from state import (
   DeviceState,
@@ -230,6 +232,31 @@ from state import (
 # =========================
 # App / State
 # =========================
+def _public_if_root_relative(url: str) -> str:
+  u = (url or "").strip()
+  if u.startswith("/") and not u.startswith("//"):
+    return public_app_path(u)
+  return u
+
+
+def _session_cookie_path() -> str:
+  return APP_BASE_PATH if APP_BASE_PATH else "/"
+
+
+def _client_los_proxy_url() -> str:
+  p = (LOS_ELEVATION_PROXY_URL or "").strip()
+  if p.startswith("/") and not p.startswith("//"):
+    return public_app_path(p)
+  return p
+
+
+def _client_weather_radar_lookup_url() -> str:
+  p = (WEATHER_RADAR_COUNTRY_LOOKUP_URL or "").strip()
+  if p.startswith("/") and not p.startswith("//"):
+    return public_app_path(p)
+  return p
+
+
 mqtt_client: Optional[mqtt.Client] = None
 background_tasks: Set[asyncio.Task[Any]] = set()
 clients: Set[WebSocket] = set()
@@ -2636,7 +2663,9 @@ def root(request: Request):
     replacements = {
       "SITE_TITLE": SITE_TITLE,
       "SITE_DESCRIPTION": SITE_DESCRIPTION,
-      "SITE_ICON": SITE_ICON,
+      "SITE_ICON": _public_if_root_relative(SITE_ICON),
+      "APP_BASE_PATH": APP_BASE_PATH,
+      "STATIC_BASE": public_app_path("/static"),
       "TURNSTILE_SITE_KEY": TURNSTILE_SITE_KEY,
       "ASSET_VERSION": ASSET_VERSION,
     }
@@ -2697,7 +2726,8 @@ def root(request: Request):
         # Fallback: construct from request
         scheme = request.url.scheme
         host = request.headers.get("host", request.url.hostname or "localhost")
-        preview_url = f"{scheme}://{host}/preview.png?{preview_params}"
+        preview_path = public_app_path("/preview.png")
+        preview_url = f"{scheme}://{host}{preview_path}?{preview_params}"
 
       safe_image = html.escape(preview_url, quote=True)
       # Add image dimensions for better Discord/social media compatibility
@@ -2754,7 +2784,13 @@ def root(request: Request):
     "SITE_URL":
       SAFE_OG_URL,
     "SITE_ICON":
-      SITE_ICON,
+      _public_if_root_relative(SITE_ICON),
+    "APP_BASE_PATH":
+      APP_BASE_PATH,
+    "MANIFEST_HREF":
+      public_app_path("/manifest.webmanifest"),
+    "STATIC_BASE":
+      public_app_path("/static"),
     "SITE_FEED_NOTE":
       SITE_FEED_NOTE,
     "CUSTOM_LINK_URL":
@@ -2802,7 +2838,7 @@ def root(request: Request):
     "LOS_ELEVATION_URL":
       LOS_ELEVATION_URL,
     "LOS_ELEVATION_PROXY_URL":
-      LOS_ELEVATION_PROXY_URL,
+      _client_los_proxy_url(),
     "LOS_SAMPLE_MIN":
       LOS_SAMPLE_MIN,
     "LOS_SAMPLE_MAX":
@@ -2830,7 +2866,7 @@ def root(request: Request):
     "WEATHER_RADAR_COUNTRY_BOUNDS_ENABLED":
       str(WEATHER_RADAR_COUNTRY_BOUNDS_ENABLED).lower(),
     "WEATHER_RADAR_COUNTRY_LOOKUP_URL":
-      WEATHER_RADAR_COUNTRY_LOOKUP_URL,
+      _client_weather_radar_lookup_url(),
     "WEATHER_WIND_ENABLED":
       str(WEATHER_WIND_ENABLED).lower(),
     "WEATHER_WIND_API_URL":
@@ -3163,8 +3199,9 @@ def map_page(request: Request):
   # If Turnstile is enabled and user isn't authenticated, redirect to landing
   if TURNSTILE_ENABLED and not _check_turnstile_auth(request):
     print("[map] Unauthenticated user accessing /map, redirecting to /")
+    home = html.escape(public_app_path("/"), quote=True)
     return HTMLResponse(
-      "<script>window.location.href = '/';</script>",
+      f"<script>window.location.href = '{home}';</script>",
       status_code=303,
     )
 
@@ -3200,7 +3237,10 @@ def map_page(request: Request):
     "SITE_TITLE": SITE_TITLE,
     "SITE_DESCRIPTION": SITE_DESCRIPTION,
     "SITE_URL": SAFE_OG_URL,
-    "SITE_ICON": SITE_ICON,
+    "SITE_ICON": _public_if_root_relative(SITE_ICON),
+    "APP_BASE_PATH": APP_BASE_PATH,
+    "MANIFEST_HREF": public_app_path("/manifest.webmanifest"),
+    "STATIC_BASE": public_app_path("/static"),
     "SITE_FEED_NOTE": SITE_FEED_NOTE,
     "CUSTOM_LINK_URL": CUSTOM_LINK_URL,
     "PACKET_ANALYZER_URL": PACKET_ANALYZER_URL,
@@ -3224,7 +3264,7 @@ def map_page(request: Request):
     "MAP_BOUNDARY_NAME": get_map_boundary_name(),
     "MAP_DEFAULT_LAYER": MAP_DEFAULT_LAYER,
     "LOS_ELEVATION_URL": LOS_ELEVATION_URL,
-    "LOS_ELEVATION_PROXY_URL": LOS_ELEVATION_PROXY_URL,
+    "LOS_ELEVATION_PROXY_URL": _client_los_proxy_url(),
     "LOS_SAMPLE_MIN": LOS_SAMPLE_MIN,
     "LOS_SAMPLE_MAX": LOS_SAMPLE_MAX,
     "LOS_SAMPLE_STEP_METERS": LOS_SAMPLE_STEP_METERS,
@@ -3238,7 +3278,7 @@ def map_page(request: Request):
     "COVERAGE_API_URL": COVERAGE_API_URL,
     "WEATHER_RADAR_ENABLED": str(WEATHER_RADAR_ENABLED).lower(),
     "WEATHER_RADAR_COUNTRY_BOUNDS_ENABLED": str(WEATHER_RADAR_COUNTRY_BOUNDS_ENABLED).lower(),
-    "WEATHER_RADAR_COUNTRY_LOOKUP_URL": WEATHER_RADAR_COUNTRY_LOOKUP_URL,
+    "WEATHER_RADAR_COUNTRY_LOOKUP_URL": _client_weather_radar_lookup_url(),
     "WEATHER_WIND_ENABLED": str(WEATHER_WIND_ENABLED).lower(),
     "WEATHER_WIND_API_URL": WEATHER_WIND_API_URL,
     "WEATHER_WIND_GRID_SIZE": WEATHER_WIND_GRID_SIZE,
@@ -3260,29 +3300,34 @@ def map_page(request: Request):
 @app.get("/manifest.webmanifest")
 def manifest():
   icons = []
-  if SITE_ICON:
+  icon_href = _public_if_root_relative(SITE_ICON)
+  if icon_href:
     icons = [
       {
-        "src": SITE_ICON,
+        "src": icon_href,
         "sizes": "192x192",
         "type": "image/png",
         "purpose": "any",
       },
       {
-        "src": SITE_ICON,
+        "src": icon_href,
         "sizes": "512x512",
         "type": "image/png",
         "purpose": "any maskable",
       },
     ]
   short_name = SITE_TITLE if len(SITE_TITLE) <= 12 else SITE_TITLE[:12]
+  start_url = public_app_path("/")
+  if not start_url.endswith("/"):
+    start_url += "/"
+  scope = start_url
   return JSONResponse(
     {
       "name": SITE_TITLE,
       "short_name": short_name,
       "description": SITE_DESCRIPTION,
-      "start_url": "/",
-      "scope": "/",
+      "start_url": start_url,
+      "scope": scope,
       "display": "standalone",
       "display_override": ["standalone", "minimal-ui"],
       "background_color": "#0f172a",
@@ -3341,7 +3386,21 @@ def qr_code(
 
 @app.get("/sw.js")
 def service_worker():
-  return FileResponse("static/sw.js", media_type="application/javascript")
+  sw_path = os.path.join(APP_DIR, "static", "sw.js")
+  try:
+    with open(sw_path, "r", encoding="utf-8") as handle:
+      body = handle.read()
+  except Exception:
+    return FileResponse("static/sw.js", media_type="application/javascript")
+  body = body.replace(
+    "const MESHMAP_APP_BASE = __MESHMAP_APP_BASE__;\n",
+    f"const MESHMAP_APP_BASE = {json.dumps(APP_BASE_PATH)};\n",
+  )
+  return Response(
+    content=body,
+    media_type="application/javascript",
+    headers={"Cache-Control": "no-store"},
+  )
 
 
 @app.get("/snapshot")
@@ -3858,7 +3917,7 @@ async def verify_turnstile(request: Request):
       key="meshmap_auth",
       value=auth_token,
       max_age=TURNSTILE_TOKEN_TTL_SECONDS,
-      path="/",
+      path=_session_cookie_path(),
       samesite="lax",
     )
 
@@ -3916,3 +3975,34 @@ async def ws_endpoint(ws: WebSocket):
     pass
   finally:
     clients.discard(ws)
+
+
+if APP_BASE_PATH:
+  _meshmap_fastapi_app = app
+
+  class _AppBasePathStripMiddleware:
+    """Strip APP_BASE_PATH from ASGI scope so routes stay root-relative."""
+
+    def __init__(self, inner_app, prefix: str):
+      self.inner_app = inner_app
+      self.prefix = prefix
+
+    async def __call__(self, scope, receive, send):
+      if scope["type"] in ("http", "websocket"):
+        path = scope.get("path") or ""
+        pfx = self.prefix
+        if path == pfx or path.startswith(pfx + "/"):
+          scope = dict(scope)
+          new_path = path[len(pfx):] or "/"
+          scope["path"] = new_path
+          raw = scope.get("raw_path")
+          if isinstance(raw, (bytes, bytearray)):
+            try:
+              scope["raw_path"] = new_path.encode("utf-8")
+            except Exception:
+              pass
+          prev = scope.get("root_path") or ""
+          scope["root_path"] = prev + pfx
+      await self.inner_app(scope, receive, send)
+
+  app = _AppBasePathStripMiddleware(_meshmap_fastapi_app, APP_BASE_PATH)

--- a/backend/config.py
+++ b/backend/config.py
@@ -143,6 +143,30 @@ ROUTE_HISTORY_ALLOWED_MODES_SET = {
   for s in ROUTE_HISTORY_ALLOWED_MODES.split(",") if s.strip()
 }
 
+
+def _normalize_app_base_path(raw: str) -> str:
+  """Return '' or '/livemap' (leading slash, no trailing slash)."""
+  s = (raw or "").strip()
+  if not s or s == "/":
+    return ""
+  if not s.startswith("/"):
+    s = "/" + s
+  s = s.rstrip("/")
+  return s
+
+
+APP_BASE_PATH = _normalize_app_base_path(os.getenv("APP_BASE_PATH", ""))
+
+
+def public_app_path(path: str) -> str:
+  """Prefix root-relative paths when APP_BASE_PATH is set."""
+  if not path.startswith("/"):
+    path = "/" + path
+  if not APP_BASE_PATH:
+    return path
+  return APP_BASE_PATH + path
+
+
 SITE_TITLE = os.getenv("SITE_TITLE", "Greater Boston Mesh Live Map")
 SITE_DESCRIPTION = os.getenv(
   "SITE_DESCRIPTION",

--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -222,10 +222,17 @@ const prodMode = String(config.prodMode).toLowerCase() === 'true';
 const apiToken = config.prodToken || '';
 const qrCodeButtonEnabled =
   String(config.qrCodeButtonEnabled).toLowerCase() === 'true';
+const publicPathPrefix = String(config.appBasePath || '').trim();
+const apiPath = (path) => {
+  const p = path.startsWith('/') ? path : `/${path}`;
+  if (!publicPathPrefix) return p;
+  return `${publicPathPrefix}${p}`;
+};
 const tokenHeaders = () => (prodMode && apiToken ? { 'x-access-token': apiToken } : {});
 const withToken = (path) => {
-  if (!prodMode || !apiToken) return path;
-  const url = new URL(path, window.location.origin);
+  const resolved = apiPath(path);
+  if (!prodMode || !apiToken) return resolved;
+  const url = new URL(resolved, window.location.origin);
   url.searchParams.set('token', apiToken);
   return `${url.pathname}${url.search}`;
 };
@@ -3868,7 +3875,7 @@ async function fetchLosServerResult(a, b) {
     h2: heightB.toFixed(2),
   });
   try {
-    const res = await fetch(`/los?${params.toString()}`);
+    const res = await fetch(apiPath(`/los?${params.toString()}`));
     const data = await res.json();
     if (!data.ok) {
       return { ok: false, error: data.error || 'failed' };
@@ -6521,7 +6528,7 @@ function handleRealtimeMessage(msg) {
 function connectWS() {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const wsSuffix = (prodMode && apiToken) ? `?token=${encodeURIComponent(apiToken)}` : '';
-  const ws = new WebSocket(`${proto}://${location.host}/ws${wsSuffix}`);
+  const ws = new WebSocket(`${proto}://${location.host}${apiPath('/ws')}${wsSuffix}`);
 
   ws.onopen = () => console.log("ws connected");
   ws.onclose = () => {
@@ -6661,7 +6668,9 @@ setInterval(refreshHeatLayer, 15000);
 setInterval(refreshOnlineMarkers, 30000);
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => { });
+    const swPath = apiPath('/sw.js');
+    const swScope = publicPathPrefix ? `${publicPathPrefix}/` : '/';
+    navigator.serviceWorker.register(swPath, { scope: swScope }).catch(() => { });
   });
 }
 

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -9,7 +9,7 @@
   <meta name="description" content="{{SITE_DESCRIPTION}}" />
   <link rel="icon" href="{{SITE_ICON}}" type="image/png" />
   <link rel="apple-touch-icon" href="{{SITE_ICON}}" />
-  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="manifest" href="{{MANIFEST_HREF}}" />
   <meta name="theme-color" content="#0f172a" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta property="og:title" content="{{SITE_TITLE}}" />
@@ -23,10 +23,10 @@
   {{TWITTER_IMAGE_TAG}}
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
-  <link rel="stylesheet" href="/static/styles.css?v={{ASSET_VERSION}}" />
+  <link rel="stylesheet" href="{{STATIC_BASE}}/styles.css?v={{ASSET_VERSION}}" />
 </head>
 
-<body data-map-start-lat="{{MAP_START_LAT}}" data-map-start-lon="{{MAP_START_LON}}"
+<body data-app-base-path="{{APP_BASE_PATH}}" data-map-start-lat="{{MAP_START_LAT}}" data-map-start-lon="{{MAP_START_LON}}"
   data-map-start-zoom="{{MAP_START_ZOOM}}" data-map-radius-km="{{MAP_RADIUS_KM}}"
   data-map-radius-show="{{MAP_RADIUS_SHOW}}" data-map-boundary-mode="{{MAP_BOUNDARY_MODE}}"
   data-map-boundary-show="{{MAP_BOUNDARY_SHOW}}" data-map-boundary-name="{{MAP_BOUNDARY_NAME}}"
@@ -401,7 +401,7 @@
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/leaflet.heat/dist/leaflet-heat.js" crossorigin="anonymous"></script>
 
-  <script src="/static/app.js?v={{ASSET_VERSION}}" defer></script>
+  <script src="{{STATIC_BASE}}/app.js?v={{ASSET_VERSION}}" defer></script>
 </body>
 
 </html>

--- a/backend/static/landing.html
+++ b/backend/static/landing.html
@@ -199,7 +199,7 @@
     }
   </style>
 </head>
-<body>
+<body data-app-base-path="{{APP_BASE_PATH}}">
   <div class="landing-container">
     <div class="landing-card">
       <!-- Hidden site key for turnstile.js to read without displaying it. -->
@@ -250,6 +250,6 @@
     async
     defer
   ></script>
-  <script src="/static/turnstile.js?v={{ASSET_VERSION}}"></script>
+  <script src="{{STATIC_BASE}}/turnstile.js?v={{ASSET_VERSION}}"></script>
 </body>
 </html>

--- a/backend/static/sw.js
+++ b/backend/static/sw.js
@@ -1,5 +1,10 @@
+const MESHMAP_APP_BASE = __MESHMAP_APP_BASE__;
+const meshmapHomePath = MESHMAP_APP_BASE ? `${MESHMAP_APP_BASE}/` : '/';
+const meshmapManifestPath = MESHMAP_APP_BASE
+  ? `${MESHMAP_APP_BASE}/manifest.webmanifest`
+  : '/manifest.webmanifest';
 const CACHE_NAME = 'meshmap-pwa-v6';
-const CORE_ASSETS = ['/', '/manifest.webmanifest'];
+const CORE_ASSETS = [meshmapHomePath, meshmapManifestPath];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -35,7 +40,7 @@ async function networkFirst(request) {
   } catch (err) {
     const cached = await caches.match(request);
     if (cached) return cached;
-    return caches.match('/');
+    return caches.match(meshmapHomePath);
   }
 }
 
@@ -49,7 +54,11 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  if (url.pathname.startsWith('/static/') || url.pathname === '/manifest.webmanifest') {
+  const staticPrefix = MESHMAP_APP_BASE ? `${MESHMAP_APP_BASE}/static/` : '/static/';
+  if (
+    url.pathname.startsWith(staticPrefix) ||
+    url.pathname === meshmapManifestPath
+  ) {
     event.respondWith(cacheFirst(event.request));
   }
 });

--- a/backend/static/turnstile.js
+++ b/backend/static/turnstile.js
@@ -3,6 +3,19 @@
  * Manages widget initialization, verification, and token submission
  */
 
+function meshmapPublicPathPrefix() {
+  const body = document.body;
+  if (!body || !body.dataset) return '';
+  return String(body.dataset.appBasePath || '').trim();
+}
+
+function meshmapApiPath(p) {
+  const prefix = meshmapPublicPathPrefix();
+  const path = p.startsWith('/') ? p : `/${p}`;
+  if (!prefix) return path;
+  return `${prefix}${path}`;
+}
+
 const TurnstileAuth = {
   config: {
     siteKey: new URLSearchParams(window.location.search).get('siteKey') || 
@@ -166,7 +179,7 @@ const TurnstileAuth = {
     this.log(4, 'Submitting token to server...');
 
     try {
-      const response = await fetch('/api/verify-turnstile', {
+      const response = await fetch(meshmapApiPath('/api/verify-turnstile'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -188,7 +201,12 @@ const TurnstileAuth = {
         const d = new Date();
         d.setTime(d.getTime() + (expiresIn * 1000));
         const expires = d.toUTCString();
-        document.cookie = `meshmap_auth=${data.auth_token}; expires=${expires}; path=/; SameSite=Lax`;
+        const cookiePath = meshmapPublicPathPrefix()
+          ? `${meshmapPublicPathPrefix()}/`
+          : '/';
+        document.cookie = (
+          `meshmap_auth=${data.auth_token}; expires=${expires}; path=${cookiePath}; SameSite=Lax`
+        );
         
         this.log(4, `Cookie set: meshmap_auth`);
         
@@ -198,7 +216,7 @@ const TurnstileAuth = {
 
         // Redirect to map after a short delay
         setTimeout(() => {
-          window.location.href = '/map';
+          window.location.href = meshmapApiPath('/map');
         }, 1500);
 
       } else {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       DEBUG_PAYLOAD: "${DEBUG_PAYLOAD:-false}"
       DEBUG_PAYLOAD_MAX: "${DEBUG_PAYLOAD_MAX:-400}"
       PAYLOAD_PREVIEW_MAX: "${PAYLOAD_PREVIEW_MAX:-800}"
+      APP_BASE_PATH: "${APP_BASE_PATH:-}"
       STATE_DIR: "${STATE_DIR:-/data}"
       DEVICE_COORDS_FILE: "${DEVICE_COORDS_FILE:-/data/device_coords.json}"
       NEIGHBOR_OVERRIDES_FILE: "${NEIGHBOR_OVERRIDES_FILE:-/data/neighbor_overrides.json}"


### PR DESCRIPTION
Modified all the app files related to being able to host the docker container as a subpath (url/livemap), rather than as the root. Configurable using the APP_BATH_PATH .env variable (leave blank if using at root). Haven't fully tested all the features (turnstile), but you can see how I use it to split the regions into three docker containers, each with their own subpath at https://livemap.wcmesh.com 