### PR TITLE
[codex] Add direct node links and peer distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Other community maps (versions may differ):
 - Share button that copies a URL with current view + settings
 - URL parameters to open the map at a specific view (center, zoom, toggles)
 - Node search by name or public key
-- Node popups can copy the full public key from the short key shown under the node name, with an optional MeshCore contact QR modal that shows the node name and a clickable truncated key
+- Node popups can copy the full public key from the short key shown under the node name, copy a direct `node=` map link, and optionally expose a MeshCore contact QR modal that shows the node name plus a clickable truncated key
 - Adjustable node size slider (defaults from env, saves locally)
 - LOS tool with elevation profile + peak markers, hover sync, realtime draggable endpoints (Shift+click or long‑press nodes), and Earth-curvature-aware blockage checks
 - Embeddable metadata (Open Graph/Twitter tags) driven by env vars
@@ -326,8 +326,8 @@ Use it:
 - LOS elevations are fetched via `/los/elevations` and LOS/relay math runs client-side (with `/los` fallback).
 - LOS now includes Earth curvature by default using an effective Earth radius factor of `1.333333`, unless you override the LOS curvature envs.
 - History tool always loads off (use the button or `history=on` in the URL).
-- Peers tool uses dedicated rolling peer-history buckets so 24h counts stay accurate even on high-volume meshes; peer links are still counted from route `point_ids` even when a hop could not be drawn on the map, and forced MQTT listeners are excluded from peer lists.
-- URL params override stored settings: `lat`, `lon`/`lng`/`long`, `zoom`, `layer`, `history`, `heat`, `coverage`, `weather`, `weather_radar`, `weather_wind`, `labels`, `nodes`, `legend`, `menu`, `units`, `history_filter`, `route_bytes`.
+- Peers tool uses dedicated rolling peer-history buckets so 24h counts stay accurate even on high-volume meshes; peer links are still counted from route `point_ids` even when a hop could not be drawn on the map, distances are shown in the selected km/mi units when both endpoints have coordinates, and forced MQTT listeners are excluded from peer lists.
+- URL params override stored settings: `lat`, `lon`/`lng`/`long`, `zoom`, `layer`, `history`, `heat`, `coverage`, `weather`, `weather_radar`, `weather_wind`, `labels`, `nodes`, `legend`, `menu`, `units`, `history_filter`, `route_bytes`, and direct node focus via `node`/`repeater`/`device_id`.
 - Dark map also darkens node popups for readability.
 - Route styling uses payload type: 2/5 = Message (blue), 8/9 = Trace (orange), 4 = Advert (green).
 - Turnstile browser auth (`meshmap_auth`/`?auth=`) is for map + WS session flow;
@@ -361,6 +361,7 @@ Each node includes:
 
 Peer summary:
 - `GET /peers/{device_id}?token=YOUR_TOKEN`
+  - Returns incoming/outgoing neighbors with counts/percentages from route history and `distance_m` when both endpoints have coordinates.
 
 Boundary mode:
 - Default behavior remains radius-based filtering.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,8 @@
 - Mixed-width paths remain visible in the matching byte view whenever a route contains at least one hop of that width, which keeps upgraded mixed meshes usable during rollout.
 - The selected route-byte filter can be shared with `route_bytes=all|1b|2b|3b`, but it resets to `All` on normal reloads so stale browser state does not hide routes unexpectedly.
 - Added `HEAT_DEFAULT_ON` so deployments can choose whether the Heat layer loads on or off by default before any browser-local overrides exist.
+- Node popups now include a direct map-link action that copies a URL with `node=<public-key>`; loading that link focuses and zooms to the matching node/repeater, with `repeater`, `device`, `device_id`, `public_key`, and `pubkey` accepted as aliases.
+- The Peers tool now includes peer distance in the selected km/mi units when both the selected node and peer have coordinates.
 
 ## v1.8.5 (04-30-2026)
 - Added a DockerHub publish workflow at `.github/workflows/docker-publish.yml` that builds the app from `backend/Dockerfile` and pushes multi-arch `linux/amd64` and `linux/arm64` images.

--- a/backend/app.py
+++ b/backend/app.py
@@ -3487,6 +3487,7 @@ def get_peers(device_id: str, request: Request, limit: Optional[int] = Query(Non
   if state and not _coords_are_zero(state.lat, state.lon):
     payload["lat"] = float(state.lat)
     payload["lon"] = float(state.lon)
+    _add_peer_distances(payload, float(state.lat), float(state.lon))
   payload["name"] = (
     (state.name if state else None) or device_names.get(device_id) or ""
   )
@@ -3496,6 +3497,34 @@ def get_peers(device_id: str, request: Request, limit: Optional[int] = Query(Non
                                             ) or (state.ts if state else None)
   payload["server_time"] = time.time()
   return payload
+
+
+def _add_peer_distances(
+  payload: Dict[str, Any], origin_lat: float, origin_lon: float
+) -> None:
+  if _coords_are_zero(origin_lat, origin_lon):
+    return
+  for key in ("incoming", "outgoing"):
+    peers = payload.get(key)
+    if not isinstance(peers, list):
+      continue
+    for peer in peers:
+      if not isinstance(peer, dict):
+        continue
+      lat = peer.get("lat")
+      lon = peer.get("lon")
+      if lat is None or lon is None:
+        continue
+      try:
+        peer_lat = float(lat)
+        peer_lon = float(lon)
+      except (TypeError, ValueError):
+        continue
+      if _coords_are_zero(peer_lat, peer_lon):
+        continue
+      peer["distance_m"] = round(
+        _haversine_m(origin_lat, origin_lon, peer_lat, peer_lon), 2
+      )
 
 
 def _peer_device_payload(

--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -68,6 +68,16 @@ const queryMenuVisible = parseBoolParam(
   queryParams.get('menu') || queryParams.get('hud') || queryParams.get('panel')
 );
 const queryUnits = String(queryParams.get('units') || queryParams.get('unit') || '').toLowerCase();
+const queryLinkedDevice = String(
+  queryParams.get('node') ||
+  queryParams.get('repeater') ||
+  queryParams.get('device') ||
+  queryParams.get('device_id') ||
+  queryParams.get('public_key') ||
+  queryParams.get('pubkey') ||
+  ''
+).trim();
+const linkedDeviceParamNames = ['node', 'repeater', 'device', 'device_id', 'public_key', 'pubkey'];
 const queryHistoryFilter = parseHistoryFilterParam(
   queryParams.get('history_filter') || queryParams.get('historyFilter') || queryParams.get('historyfilter')
 );
@@ -563,11 +573,14 @@ const syncLosHeightInputs = () => {
 };
 syncLosHeightInputs();
 const deviceData = new Map();
+const linkedDeviceTarget = normalizeLinkedDeviceTarget(queryLinkedDevice);
+let linkedDeviceFocusDone = !linkedDeviceTarget;
 const searchInput = document.getElementById('node-search');
 const searchResults = document.getElementById('node-search-results');
 const nodeSizeInput = document.getElementById('node-size');
 const nodeSizeValue = document.getElementById('node-size-value');
 let searchMatches = [];
+let focusDeviceToken = 0;
 const storedLabels = localStorage.getItem('meshmapShowLabels');
 let showLabels = storedLabels === 'true';
 if (storedLabels === null) {
@@ -2632,7 +2645,23 @@ function renderPeerLines(origin, incoming, outgoing) {
   }
 }
 
-function renderPeerList(target, peers, total, label) {
+function getPeerDistanceMeters(origin, peer) {
+  const apiDistance = Number(peer && peer.distance_m);
+  if (Number.isFinite(apiDistance) && apiDistance >= 0) {
+    return apiDistance;
+  }
+  if (!origin || !peer) return null;
+  const originLat = Number(origin.lat);
+  const originLon = Number(origin.lon);
+  const peerLat = Number(peer.lat);
+  const peerLon = Number(peer.lon);
+  if (![originLat, originLon, peerLat, peerLon].every(Number.isFinite)) {
+    return null;
+  }
+  return haversineMeters(originLat, originLon, peerLat, peerLon);
+}
+
+function renderPeerList(target, peers, total, label, origin = null) {
   if (!target) return;
   target.innerHTML = '';
   if (!peers || peers.length === 0) {
@@ -2647,7 +2676,11 @@ function renderPeerList(target, peers, total, label) {
     item.className = 'peer-item';
     const name = peer.name || (peer.peer_id ? `${peer.peer_id.slice(0, 8)}…` : 'Unknown');
     const percent = total > 0 ? `${peer.percent.toFixed(1)}%` : '0%';
-    item.innerHTML = `<span class="peer-name">${name}</span><span class="peer-count">${peer.count} • ${percent}</span>`;
+    const distance = formatPeerDistanceUnits(getPeerDistanceMeters(origin, peer));
+    const meta = distance
+      ? `${distance} • ${peer.count} • ${percent}`
+      : `${peer.count} • ${percent}`;
+    item.innerHTML = `<span class="peer-name">${name}</span><span class="peer-count">${meta}</span>`;
     item.addEventListener('click', () => {
       if (peer.peer_id) {
         focusDevice(peer.peer_id);
@@ -2679,10 +2712,11 @@ async function selectPeerNode(deviceId) {
     if (peersMeta) {
       peersMeta.textContent = `Incoming ${inboundTotal} • Outgoing ${outboundTotal} • ${data.window_hours || 24}h window`;
     }
-    renderPeerList(peersIn, data.incoming || [], inboundTotal, 'incoming');
-    renderPeerList(peersOut, data.outgoing || [], outboundTotal, 'outgoing');
+    const origin = { lat: data.lat, lon: data.lon };
+    renderPeerList(peersIn, data.incoming || [], inboundTotal, 'incoming', origin);
+    renderPeerList(peersOut, data.outgoing || [], outboundTotal, 'outgoing', origin);
     renderPeerLines(
-      { lat: data.lat, lon: data.lon },
+      origin,
       data.incoming || [],
       data.outgoing || []
     );
@@ -2784,6 +2818,56 @@ function deviceDisplayName(d) {
   return d.name || deviceShortId(d) || 'Unknown';
 }
 
+function normalizeLinkedDeviceTarget(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function linkedDeviceSlug(value) {
+  return normalizeLinkedDeviceTarget(value)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function deviceMatchesLinkedTarget(id, d, target) {
+  if (!target) return false;
+  const normalizedId = normalizeLinkedDeviceTarget(id);
+  if (normalizedId === target) return true;
+  if (target.length >= 6 && normalizedId.startsWith(target)) return true;
+
+  const name = d && d.name ? d.name : '';
+  const normalizedName = normalizeLinkedDeviceTarget(name);
+  if (normalizedName && normalizedName === target) return true;
+  const targetSlug = linkedDeviceSlug(target);
+  return Boolean(targetSlug && linkedDeviceSlug(name) === targetSlug);
+}
+
+function findLinkedDeviceId(target) {
+  if (!target) return null;
+  for (const [id] of deviceData.entries()) {
+    if (normalizeLinkedDeviceTarget(id) === target) return id;
+  }
+  const matches = [];
+  for (const [id, d] of deviceData.entries()) {
+    if (deviceMatchesLinkedTarget(id, d, target)) {
+      matches.push({ id, d });
+    }
+  }
+  const repeater = matches.find(({ d }) => resolveRole(d) === 'repeater');
+  return repeater ? repeater.id : (matches[0] ? matches[0].id : null);
+}
+
+function tryFocusLinkedDevice() {
+  if (linkedDeviceFocusDone || !linkedDeviceTarget) return false;
+  const id = findLinkedDeviceId(linkedDeviceTarget);
+  if (!id) return false;
+  linkedDeviceFocusDone = true;
+  if (!nodesVisible) {
+    setNodesVisible(true);
+  }
+  focusDevice(id, { fromLink: true });
+  return true;
+}
+
 function getLastSeenTs(d) {
   return d.last_seen_ts || d.ts;
 }
@@ -2874,13 +2958,25 @@ function renderSearchResults(query) {
   searchResults.hidden = false;
 }
 
-function focusDevice(id) {
+function focusDevice(id, options = {}) {
   const marker = markers.get(id);
   const d = deviceData.get(id);
   if (!marker || !d) return;
-  const targetZoom = Math.max(map.getZoom(), 13);
-  map.flyTo(marker.getLatLng(), targetZoom, { duration: 0.6 });
-  marker.openPopup();
+  const targetZoom = Math.max(map.getZoom(), Number(options.minZoom) || 13);
+  const openPopup = options.openPopup !== false;
+  const latlng = marker.getLatLng();
+  const token = ++focusDeviceToken;
+  let popupOpened = false;
+  const openAfterMove = () => {
+    if (token !== focusDeviceToken) return;
+    if (popupOpened || !openPopup) return;
+    popupOpened = true;
+    refreshViewportLayers();
+    marker.openPopup();
+  };
+  map.once('moveend', openAfterMove);
+  map.flyTo(latlng, targetZoom, { duration: options.fromLink ? 0.35 : 0.6 });
+  window.setTimeout(openAfterMove, options.fromLink ? 450 : 700);
   if (searchInput) searchInput.value = '';
   if (searchResults) {
     searchResults.hidden = true;
@@ -3436,6 +3532,20 @@ function formatDistanceUnits(meters) {
   }
   if (value >= 1000) return `${(value / 1000).toFixed(2)} km`;
   return `${Math.round(value)} m`;
+}
+
+function formatPeerDistanceUnits(meters) {
+  if (meters == null) return '';
+  const value = Number(meters);
+  if (!Number.isFinite(value) || value < 0) return '';
+  if (distanceUnits === 'mi') {
+    const miles = value / 1609.344;
+    const decimals = miles < 10 ? 1 : 0;
+    return `${miles.toFixed(decimals)} mi`;
+  }
+  const km = value / 1000.0;
+  const decimals = km < 10 ? 1 : 0;
+  return `${km.toFixed(decimals)} km`;
 }
 
 function formatDistanceMeters(meters) {
@@ -5387,6 +5497,16 @@ function makePopup(d) {
       >Generate QR Code</button>
     `);
   }
+  if (publicKey) {
+    const linkLabel = role === 'repeater' ? 'Copy repeater link' : 'Copy node link';
+    popupActions.push(`
+      <button
+        type="button"
+        class="popup-action-button"
+        data-node-link-id="${escapeHtmlAttr(publicKey)}"
+      >${linkLabel}</button>
+    `);
+  }
   return `
         ${title}
         <span class="small">
@@ -5508,6 +5628,11 @@ function upsertDevice(d, trail) {
         if (btn.dataset.boundQr === 'true') return;
         btn.dataset.boundQr = 'true';
         btn.addEventListener('click', handleQrPopupClick);
+      });
+      root.querySelectorAll('.popup-action-button[data-node-link-id]').forEach((btn) => {
+        if (btn.dataset.boundNodeLink === 'true') return;
+        btn.dataset.boundNodeLink = 'true';
+        btn.addEventListener('click', copyNodeLink);
       });
     });
     m.__suppressClick = false;
@@ -6404,6 +6529,7 @@ async function initialSnapshot() {
         const trail = snap.trails ? snap.trails[id] : null;
         upsertDevice(d, trail);
       }
+      tryFocusLinkedDevice();
     }
     if (Array.isArray(snap.heat)) {
       seedHeat(snap.heat);
@@ -6457,6 +6583,7 @@ function queueRealtimeMessage(msg) {
 function handleRealtimeMessage(msg) {
   if (msg.type === "update") {
     upsertDevice(msg.device, msg.trail);
+    tryFocusLinkedDevice();
     return;
   }
 
@@ -6541,6 +6668,7 @@ function connectWS() {
           const trail = msg.trails ? msg.trails[id] : null;
           upsertDevice(d, trail);
         }
+        tryFocusLinkedDevice();
         clearRoutes();
         if (Array.isArray(msg.heat)) {
           seedHeat(msg.heat);
@@ -6803,6 +6931,91 @@ if (initialUpdateAvailable) {
   });
 }
 
+function clearLinkedDeviceParams(url) {
+  linkedDeviceParamNames.forEach((name) => url.searchParams.delete(name));
+}
+
+function buildMapShareUrl(options = {}) {
+  const center = options.center || map.getCenter();
+  const lat = Number(center.lat);
+  const lon = Number(center.lng ?? center.lon);
+  const zoom = options.zoom == null ? map.getZoom() : options.zoom;
+  const url = new URL(window.location.href);
+  clearLinkedDeviceParams(url);
+  if (Number.isFinite(lat)) url.searchParams.set('lat', lat.toFixed(5));
+  if (Number.isFinite(lon)) url.searchParams.set('lon', lon.toFixed(5));
+  url.searchParams.set('zoom', String(zoom));
+  url.searchParams.set('layer', baseLayer);
+  url.searchParams.set('history', historyVisible ? 'on' : 'off');
+  url.searchParams.set('heat', heatVisible ? 'on' : 'off');
+  url.searchParams.set('coverage', coverageVisible ? 'on' : 'off');
+  url.searchParams.set('weather', radarVisible ? 'on' : 'off');
+  url.searchParams.set('weather_radar', weatherRadarLayerEnabled ? 'on' : 'off');
+  url.searchParams.set('weather_wind', weatherWindLayerEnabled ? 'on' : 'off');
+  url.searchParams.set('labels', showLabels ? 'on' : 'off');
+  url.searchParams.set('nodes', nodesVisible ? 'on' : 'off');
+  url.searchParams.set(
+    'legend',
+    hud && hud.classList.contains('legend-collapsed') ? 'off' : 'on'
+  );
+  url.searchParams.set(
+    'menu',
+    hud && hud.classList.contains('panel-hidden') ? 'off' : 'on'
+  );
+  url.searchParams.set('units', distanceUnits);
+  url.searchParams.set('history_filter', String(historyFilterMode));
+  url.searchParams.set('route_bytes', routeByteFilter);
+  if (options.deviceId) {
+    url.searchParams.set('node', options.deviceId);
+    url.searchParams.set('nodes', 'on');
+  }
+  return url.toString();
+}
+
+function buildDeviceLink(id, d) {
+  const marker = markers.get(id);
+  const markerLatLng = marker && marker.getLatLng ? marker.getLatLng() : null;
+  const lat = markerLatLng ? markerLatLng.lat : Number(d && d.lat);
+  const lon = markerLatLng ? markerLatLng.lng : Number(d && d.lon);
+  return buildMapShareUrl({
+    center: { lat, lon },
+    zoom: Math.max(map.getZoom(), 13),
+    deviceId: id
+  });
+}
+
+async function copyTextWithFallback(text, promptLabel) {
+  let copied = false;
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+    }
+  } catch (_err) {
+    copied = false;
+  }
+  if (!copied) {
+    window.prompt(promptLabel, text);
+  }
+  return copied;
+}
+
+async function copyNodeLink(ev) {
+  const btn = ev?.currentTarget;
+  const id = btn?.dataset?.nodeLinkId || '';
+  if (!btn || !id) return;
+  ev.preventDefault();
+  ev.stopPropagation();
+  const d = deviceData.get(id);
+  const link = buildDeviceLink(id, d);
+  const original = btn.textContent || 'Copy link';
+  const copied = await copyTextWithFallback(link, 'Copy node link:');
+  btn.textContent = copied ? 'Copied' : original;
+  window.setTimeout(() => {
+    btn.textContent = original;
+  }, 1200);
+}
+
 const shareToggle = document.getElementById('share-toggle');
 if (qrModalClose) {
   qrModalClose.addEventListener('click', closeQrModal);
@@ -6825,38 +7038,7 @@ if (shareToggle) {
     shareToggle.setAttribute('title', 'Copy share link');
   };
   shareToggle.addEventListener('click', async () => {
-    const center = map.getCenter();
-    const url = new URL(window.location.href);
-    url.searchParams.set('lat', center.lat.toFixed(5));
-    url.searchParams.set('lon', center.lng.toFixed(5));
-    url.searchParams.set('zoom', String(map.getZoom()));
-    url.searchParams.set('layer', baseLayer);
-    url.searchParams.set('history', historyVisible ? 'on' : 'off');
-    url.searchParams.set('heat', heatVisible ? 'on' : 'off');
-    url.searchParams.set('coverage', coverageVisible ? 'on' : 'off');
-    url.searchParams.set('weather', radarVisible ? 'on' : 'off');
-    url.searchParams.set('weather_radar', weatherRadarLayerEnabled ? 'on' : 'off');
-    url.searchParams.set('weather_wind', weatherWindLayerEnabled ? 'on' : 'off');
-    url.searchParams.set('labels', showLabels ? 'on' : 'off');
-    url.searchParams.set('nodes', nodesVisible ? 'on' : 'off');
-    url.searchParams.set('legend', hud && hud.classList.contains('legend-collapsed') ? 'off' : 'on');
-    url.searchParams.set('menu', hud && hud.classList.contains('panel-hidden') ? 'off' : 'on');
-    url.searchParams.set('units', distanceUnits);
-    url.searchParams.set('history_filter', String(historyFilterMode));
-    url.searchParams.set('route_bytes', routeByteFilter);
-    const shareUrl = url.toString();
-    let copied = false;
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(shareUrl);
-        copied = true;
-      }
-    } catch (err) {
-      copied = false;
-    }
-    if (!copied) {
-      window.prompt('Copy share link:', shareUrl);
-    }
+    await copyTextWithFallback(buildMapShareUrl(), 'Copy share link:');
     shareToggle.classList.add('copied');
     shareToggle.setAttribute('aria-label', 'Share link copied');
     shareToggle.setAttribute('title', 'Share link copied');
@@ -6924,6 +7106,13 @@ function setDistanceUnits(units, persist = true) {
   }
   if (activeRouteDetailsMeta && routeDetailsPanel && !routeDetailsPanel.hidden) {
     showRouteDetails(activeRouteDetailsMeta);
+  }
+  if (peersData) {
+    const inboundTotal = peersData.incoming_total || 0;
+    const outboundTotal = peersData.outgoing_total || 0;
+    const origin = { lat: peersData.lat, lon: peersData.lon };
+    renderPeerList(peersIn, peersData.incoming || [], inboundTotal, 'incoming', origin);
+    renderPeerList(peersOut, peersData.outgoing || [], outboundTotal, 'outgoing', origin);
   }
   if (radarVisible && weatherWindEnabled && weatherWindLayerEnabled) {
     refreshWeatherWindLayer({ silent: true, background: true });

--- a/backend/static/styles.css
+++ b/backend/static/styles.css
@@ -1092,14 +1092,18 @@
     }
 
     .peer-item .peer-name {
+      min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
 
     .peer-item .peer-count {
+      flex: 0 0 auto;
       opacity: 0.8;
+      text-align: right;
       font-variant-numeric: tabular-nums;
+      white-space: nowrap;
     }
 
     @media (max-width: 900px) {

--- a/docs.md
+++ b/docs.md
@@ -38,7 +38,7 @@ This project renders live MeshCore traffic on a Leaflet + OpenStreetMap map. A F
 - `curl -s http://localhost:8080/snapshot` (current device map).
 - `curl -s http://localhost:8080/stats` (counters, route types).
 - `curl -s http://localhost:8080/debug/last` (recent MQTT decode/debug entries).
-- `curl -s http://localhost:8080/peers/<device_id>` (peer counts for a node; uses route history).
+- `curl -s http://localhost:8080/peers/<device_id>` (peer counts/distances for a node; uses route history).
 
 ## Env Notes (Recent Additions)
 - `CUSTOM_LINK_URL` adds a HUD link button; blank hides it.
@@ -110,7 +110,7 @@ This project renders live MeshCore traffic on a Leaflet + OpenStreetMap map. A F
 - Base map toggle: Light/Dark/Topo; persisted to localStorage.
 - Dark map also darkens node popups for readability.
 - Node popups do not auto-pan; dragging the map won’t snap back to keep a popup in view.
-- Node popups now let users click the short key under the node name to copy the full public key, and can optionally expose a MeshCore-compatible contact QR modal that shows the node name plus a clickable truncated key that still copies the full public key.
+- Node popups now let users click the short key under the node name to copy the full public key, copy a direct `node=` map link, and can optionally expose a MeshCore-compatible contact QR modal that shows the node name plus a clickable truncated key that still copies the full public key.
 - Legend is collapsible and persisted to localStorage.
 - HUD is capped to `90vh` and scrolls to avoid running off-screen.
 - Map start position is configurable with `MAP_START_LAT`, `MAP_START_LON`, `MAP_START_ZOOM`.
@@ -125,7 +125,7 @@ This project renders live MeshCore traffic on a Leaflet + OpenStreetMap map. A F
 - History panel can be dismissed with the X button while keeping history lines visible (toggle History tool to show it again).
 - History slider modes: 0 = All, 1 = Blue only, 2 = Yellow only, 3 = Yellow + Red, 4 = Red only.
 - History legend swatch is hidden unless the History tool is active.
-- Peers tool shows incoming/outgoing neighbors for a selected node, with counts and percentages pulled from dedicated rolling peer-history buckets instead of raw route-history segments.
+- Peers tool shows incoming/outgoing neighbors for a selected node, with counts and percentages pulled from dedicated rolling peer-history buckets instead of raw route-history segments. When both endpoints have coordinates, it also shows peer distance in the selected km/mi units.
 - Peer-history buckets are also updated from adjacent route `point_ids` when a hop cannot be rendered as a visible map segment, so peer counts do not drop to zero just because a route endpoint lacked usable coordinates.
 - Peers tool skips nodes listed in `MQTT_ONLINE_FORCE_NAMES` (observer listeners).
 - Peers panel legend clarifies line colors (incoming = blue, outgoing = purple).
@@ -160,7 +160,7 @@ This project renders live MeshCore traffic on a Leaflet + OpenStreetMap map. A F
 - Optional custom HUD link appears when `CUSTOM_LINK_URL` is set.
 - Update banner shows when `GIT_CHECK_ENABLED=true` and the repo is behind; users can dismiss it per remote SHA.
 - Update banner dismissal relies on `.hud-update[hidden]` to ensure the banner actually disappears.
-- URL params override stored settings: `lat`, `lon`/`lng`/`long`, `zoom`, `layer`, `history`, `heat`, `coverage`, `weather`, `weather_radar`, `weather_wind`, `labels`, `nodes`, `legend`, `menu`, `units`, `history_filter`, `route_bytes`.
+- URL params override stored settings: `lat`, `lon`/`lng`/`long`, `zoom`, `layer`, `history`, `heat`, `coverage`, `weather`, `weather_radar`, `weather_wind`, `labels`, `nodes`, `legend`, `menu`, `units`, `history_filter`, `route_bytes`, and direct node focus via `node`/`repeater`/`device_id`.
 - Service worker uses `no-store` for navigation requests so env-driven UI toggles (like the radius ring) update without clearing site data.
 - HUD scrollbars are custom styled in Chromium for a cleaner look.
 

--- a/tests/test_peer_history_stats.py
+++ b/tests/test_peer_history_stats.py
@@ -10,6 +10,9 @@ def _clear_peer_state():
   state.route_history_segments.clear()
   state.route_history_edges.clear()
   state.peer_history_pairs.clear()
+  state.devices.clear()
+  state.device_names.clear()
+  state.device_roles.clear()
 
 
 def _route(ts):
@@ -112,3 +115,42 @@ def test_peer_history_records_route_ids_without_drawn_segments(monkeypatch):
   assert inbound["incoming_total"] == 1
   assert outbound["outgoing"][0]["peer_id"] == "BB001111"
   assert inbound["incoming"][0]["peer_id"] == "AA001111"
+
+
+def test_get_peers_adds_distance_m_for_located_peers(monkeypatch):
+  _clear_peer_state()
+  now = time.time()
+  bucket = history._peer_history_bucket_start(now)
+
+  monkeypatch.setattr(app, "PROD_MODE", False)
+  monkeypatch.setattr(app, "ROUTE_HISTORY_HOURS", 24)
+  state.devices["AA001111"] = state.DeviceState(
+    device_id="AA001111",
+    lat=42.3601,
+    lon=-71.0589,
+    ts=now,
+    name="Origin",
+    role="repeater",
+  )
+  state.devices["BB001111"] = state.DeviceState(
+    device_id="BB001111",
+    lat=42.3611,
+    lon=-71.0579,
+    ts=now,
+    name="Peer",
+    role="repeater",
+  )
+  state.peer_history_pairs["AA001111:BB001111"] = {
+    "a_id": "AA001111",
+    "b_id": "BB001111",
+    "buckets": {str(bucket): 3},
+  }
+
+  payload = app.get_peers("AA001111", None, limit=8)
+  peer = payload["outgoing"][0]
+  expected = app._haversine_m(42.3601, -71.0589, 42.3611, -71.0579)
+
+  assert payload["lat"] == 42.3601
+  assert payload["lon"] == -71.0589
+  assert peer["peer_id"] == "BB001111"
+  assert peer["distance_m"] == round(expected, 2)


### PR DESCRIPTION
## Summary

- Add direct node/repeater map links via `node=` plus alias params, and focus/zoom/open the matching popup when a link is loaded.
- Add popup actions to copy direct node or repeater links without carrying stale node params into normal map share links.
- Add peer distance support from `/peers/{device_id}` and render distances in the Peers panel using the selected km/mi units.
- Update docs/version notes and add regression coverage for peer distance payloads.

## Validation

- `uv run --with-requirements requirements-dev.txt pytest` -> `94 passed, 2 skipped`
- `uv run --with-requirements requirements-dev.txt pytest tests/test_peer_history_stats.py -q` -> `4 passed`
- `node --check backend/static/app.js` -> passed
- `git diff --check` -> passed
- Runtime/API smoke: `/peers/AA001111` returned `distance_m: 995.94`
- Browser smoke: `/?node=AA001111&units=km&nodes=on&menu=on&zoom=10` focused the linked repeater, opened its popup, exposed `Copy repeater link`, and the Peers panel showed `1.0 km` then `0.6 mi` after switching units.