### PR TITLE
ci: enable Dependabot updates for dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Configure weekly Dependabot version checks for Python, Docker, and GitHub Actions dependencies. All update pull requests target `dev`; the configuration lives on the default branch because GitHub only loads `.github/dependabot.yml` from there.

Validation:
- Parsed the YAML successfully
- Confirmed all three ecosystems target `dev`